### PR TITLE
Adding a basic backup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN \
 
 COPY scripts/instance-status.sh /usr/local/bin/instance-status.sh
 COPY scripts/instance-status-handler.sh /usr/local/bin/instance-status-handler.sh
+COPY services/consul_backup.json /consul/config/consul_backup.json
+COPY scripts/consul-backup.sh /usr/local/bin/consul-backup.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # docker-consul
+
+
+### Customizations ontop of the standard consul image
+
+We create a InstanceStatus services which attempts to determain if the instance is running is Terminating:Wait state, and if so to gracefully exit the cluster.  - Useful for autoscaling events. 
+
+S3_BUCKET - if S3_BUCKET is passed as an env var it will enable a consul backup script. This script requires write access to the backup bucket

--- a/scripts/consul-backup.sh
+++ b/scripts/consul-backup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+: ${S3_BUCKET}
+DC=$(curl -s http://localhost:8500/v1/catalog/datacenters | jq -r .[])
+FILE="/tmp/$(hostname).snap"
+
+if [ ${S3_BUCKET} ]; then
+  consul snapshot save $FILE
+  /usr/bin/aws s3 mv ${FILE} s3://${S3_BUCKET}/${DC}/consul/
+else
+  echo "S3_BUCKET is not set, consul-backup.sh is disabled."
+  exit 0
+fi

--- a/services/consul_backup.json
+++ b/services/consul_backup.json
@@ -1,0 +1,11 @@
+{
+  "service": {
+    "name": "ConsulBackup",
+    "checks": [
+      {
+        "script": "/usr/local/bin/consul-backup.sh",
+        "interval": "10s"
+      }
+    ]
+  }
+}

--- a/services/consul_backup.json
+++ b/services/consul_backup.json
@@ -4,7 +4,7 @@
     "checks": [
       {
         "script": "/usr/local/bin/consul-backup.sh",
-        "interval": "10s"
+        "interval": "300s"
       }
     ]
   }

--- a/services/consul_backup.json
+++ b/services/consul_backup.json
@@ -4,7 +4,7 @@
     "checks": [
       {
         "script": "/usr/local/bin/consul-backup.sh",
-        "interval": "300s"
+        "interval": "3600s"
       }
     ]
   }

--- a/services/consul_backup.json
+++ b/services/consul_backup.json
@@ -4,6 +4,7 @@
     "checks": [
       {
         "script": "/usr/local/bin/consul-backup.sh",
+        "status": "passing",
         "interval": "3600s"
       }
     ]


### PR DESCRIPTION
If the S3_BUCKET env var isnt' passed to this script, it does nothing, and sets it's health-check to "passing" 